### PR TITLE
fix: add React Native entrypoint

### DIFF
--- a/packages/convert/package.json
+++ b/packages/convert/package.json
@@ -47,6 +47,7 @@
 		}
 	},
 	"main": "./dist/index.js",
+	"react-native": "./dist/index.js",
 	"jsdelivr": "./dist/convert.prod.mjs",
 	"unpkg": "./dist/convert.prod.mjs",
 	"module": "./dist/convert.prod.mjs",


### PR DESCRIPTION
react native bundler metro, doesn't support mjs, since it fallsback to "browser" key this breaks usage in react native apps