### PR TITLE
fix: stop using dynamic imports in React Native entrypoint

### DIFF
--- a/packages/convert/package.json
+++ b/packages/convert/package.json
@@ -47,7 +47,7 @@
 		}
 	},
 	"main": "./dist/index.js",
-	"react-native": "./dist/index.js",
+	"react-native": "./dist/convert.prod.js",
 	"jsdelivr": "./dist/convert.prod.mjs",
 	"unpkg": "./dist/convert.prod.mjs",
 	"module": "./dist/convert.prod.mjs",


### PR DESCRIPTION
Hey, just an update on what I had done before, react native metro bundler doesn't support dynamic requires.
Thanks!