### PR TITLE
Adds getMeasure function, which returns the measure associated with a unit.

### DIFF
--- a/docs/convert.api.md
+++ b/docs/convert.api.md
@@ -55,6 +55,12 @@ export type Energy = UnitsByMeasure<MeasureKind.Energy>;
 export type Force = UnitsByMeasure<MeasureKind.Force>;
 
 // @public
+export function getMeasureKind<U extends Unit>(unit: U): _MeasureKindByUnit<U>;
+
+// @public
+export function getMeasureKind(unit: string): MeasureKind | undefined;
+
+// @public
 export type Length = UnitsByMeasure<MeasureKind.Length>;
 
 // @internal (undocumented)

--- a/package.json
+++ b/package.json
@@ -89,17 +89,17 @@
 		},
 		{
 			"gzip": true,
-			"limit": "6.91 KB",
+			"limit": "6.93 KB",
 			"path": "./dist/index.js"
 		},
 		{
 			"brotli": true,
-			"limit": "5.27 KB",
+			"limit": "5.30 KB",
 			"path": "./dist/index.mjs"
 		},
 		{
 			"gzip": true,
-			"limit": "6.67 KB",
+			"limit": "6.68 KB",
 			"path": "./dist/index.mjs"
 		}
 	]

--- a/src/converters/convert.ts
+++ b/src/converters/convert.ts
@@ -2,7 +2,7 @@ import type { BestKind, MeasureKind } from '../conversions/types';
 import { bestUnits } from '../generated/best-units';
 import { differences, unitsObject } from '../generated/parse-unit';
 import type { BestConversion, Converter } from '../types/converter';
-import type { BestUnitsForUnit, MeasureKindByUnit, MeasuresByUnit, Unit } from '../types/units';
+import type { BestUnitsForUnit, MeasuresByUnit, Unit } from '../types/units';
 import type { LiteralToPrimitive } from '../types/utils';
 
 // Importing MeasureKind will cause the entire enum to be included in the output, which increases bundle size
@@ -147,11 +147,4 @@ export function convert<Q extends number | bigint, U extends Unit>(
 	return {
 		to: convertToAny.bind({ _quantity: quantity, _from: from }),
 	} as Converter<Q, MeasuresByUnit<U>>;
-}
-
-export function getMeasure<U extends Unit>(unit: U): MeasureKindByUnit<U> {
-	if (!(unit in unitsObject)) {
-		throw new RangeError(`${unit} is not a valid unit`);
-	}
-	return unitsObject[unit][0] as MeasureKindByUnit<U>;
 }

--- a/src/converters/convert.ts
+++ b/src/converters/convert.ts
@@ -2,7 +2,7 @@ import type { BestKind, MeasureKind } from '../conversions/types';
 import { bestUnits } from '../generated/best-units';
 import { differences, unitsObject } from '../generated/parse-unit';
 import type { BestConversion, Converter } from '../types/converter';
-import type { BestUnitsForUnit, MeasuresByUnit, Unit } from '../types/units';
+import type { BestUnitsForUnit, MeasureKindByUnit, MeasuresByUnit, Unit } from '../types/units';
 import type { LiteralToPrimitive } from '../types/utils';
 
 // Importing MeasureKind will cause the entire enum to be included in the output, which increases bundle size
@@ -147,4 +147,11 @@ export function convert<Q extends number | bigint, U extends Unit>(
 	return {
 		to: convertToAny.bind({ _quantity: quantity, _from: from }),
 	} as Converter<Q, MeasuresByUnit<U>>;
+}
+
+export function getMeasure<U extends Unit>(unit: U): MeasureKindByUnit<U> {
+	if (!(unit in unitsObject)) {
+		throw new RangeError(`${unit} is not a valid unit`);
+	}
+	return unitsObject[unit][0] as MeasureKindByUnit<U>;
 }

--- a/src/converters/get-measure-kind.test.ts
+++ b/src/converters/get-measure-kind.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from 'vitest';
+import { MeasureKind } from '../conversions/types';
+import { getMeasureKind } from './get-measure-kind';
+
+describe('get measure kind', () => {
+	test('returns measure kind for valid units', () => {
+		expect(getMeasureKind('m')).toBe(MeasureKind.Length);
+		expect(getMeasureKind('s')).toBe(MeasureKind.Time);
+		expect(getMeasureKind('kg')).toBe(MeasureKind.Mass);
+	});
+
+	test('returns undefined on invalid units', () => {
+		expect(getMeasureKind('invalid')).toBeUndefined();
+		expect(getMeasureKind('__proto__')).toBeUndefined();
+	});
+});

--- a/src/converters/get-measure-kind.ts
+++ b/src/converters/get-measure-kind.ts
@@ -1,0 +1,50 @@
+import type { MeasureKind } from '../conversions/types';
+import { unitsObject } from '../generated/parse-unit';
+import type { MeasureKindByUnit, Unit } from '../types/units';
+
+/**
+ * Get the {@link MeasureKind} associated with a unit.
+ *
+ * @example
+ * ```ts
+ * getMeasure('m'); // MeasureKind.Length
+ * ```
+ * @example
+ * ```ts
+ * getMeasure('invalid'); // undefined
+ * ```
+ *
+ * @param unit - The unit you want to get the measure kind of
+ * @returns The {@link MeasureKind} corresponding to this unit of measure, or `undefined` if the unit is invalid
+ *
+ * @public
+ */
+export function getMeasureKind<U extends Unit>(unit: U): MeasureKindByUnit<U>;
+/**
+ * Get the {@link MeasureKind} associated with a unit.
+ *
+ * @example
+ * ```ts
+ * getMeasure('m'); // MeasureKind.Length
+ * ```
+ * @example
+ * ```ts
+ * getMeasure('invalid'); // undefined
+ * ```
+ *
+ * @param unit - The unit you want to get the measure kind of
+ * @returns The {@link MeasureKind} corresponding to this unit of measure, or `undefined` if the unit is invalid
+ *
+ * @public
+ */
+export function getMeasureKind(unit: string): MeasureKind | undefined;
+export function getMeasureKind<U extends Unit>(unit: U): MeasureKindByUnit<U> | undefined {
+	const unitObject = unitsObject[unit];
+
+	if (unitObject) {
+		return unitObject[0] as MeasureKindByUnit<U>;
+	}
+
+	// Needed to appease tsc
+	return;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,8 @@ export type { BestKind, MeasureKind } from './conversions/types';
 // biome-ignore lint/performance/noBarrelFile: This is the library entrypoint
 export { convertMany } from './converters/convert-many';
 // biome-ignore lint/style/noDefaultExport: This is a default export we want
-export { convert, convert as default, getMeasure } from './converters/convert';
+export { convert, convert as default } from './converters/convert';
+export { getMeasureKind } from './converters/get-measure-kind';
 export { ms } from './converters/ms';
 export type { UnitsByMeasure as _UnitsByMeasureRaw } from './generated/types';
 export type { BestConversion, Converter } from './types/converter';

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ export type { BestKind, MeasureKind } from './conversions/types';
 // biome-ignore lint/performance/noBarrelFile: This is the library entrypoint
 export { convertMany } from './converters/convert-many';
 // biome-ignore lint/style/noDefaultExport: This is a default export we want
-export { convert, convert as default } from './converters/convert';
+export { convert, convert as default, getMeasure } from './converters/convert';
 export { ms } from './converters/ms';
 export type { UnitsByMeasure as _UnitsByMeasureRaw } from './generated/types';
 export type { BestConversion, Converter } from './types/converter';


### PR DESCRIPTION
This utility function is a bit niche, but we have use cases where it'd be nice for certain areas of code to be able to accept a unit of arbitrary measure, then perform different logic based on the measure. We're currently doing this in userland by just maintaining a list of known units ourselves, but since the information is already present in the library it'd be nice to have access to the "canonical" mapping.