### PR TITLE
build: fix Knip errors

### DIFF
--- a/knip.ts
+++ b/knip.ts
@@ -5,7 +5,8 @@ const config: KnipConfig = {
 	entry: ['src/index.ts', 'src/**/*.bench.ts'],
 
 	// Referenced as a string in rollup.config.ts
-	ignoreDependencies: ['@babel/preset-env'],
+	// @vitest/coverage-v8 is dynamically loaded by vitest when coverage.provider is 'v8'
+	ignoreDependencies: ['@babel/preset-env', '@vitest/coverage-v8'],
 };
 
 export default config;

--- a/test/legacy.cjs
+++ b/test/legacy.cjs
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var lib = require('../../convert/dist/index');
+var lib = require('../dist/index');
 
 assert.strictEqual(lib.convert(5, 'miles').to('km'), 8.04672);
 assert.strictEqual(lib.convertMany('4d 16h').to('minutes'), 6720);


### PR DESCRIPTION
Fixes two knip validation errors:

- Added @vitest/coverage-v8 to ignoreDependencies since it's dynamically loaded by vitest's coverage provider
- Fixed import path in test/legacy.cjs from incorrect relative path to correct one