### PR TITLE
fix(volume): fix conversion ratio for cubic miles

### DIFF
--- a/src/conversions/measures/volume.ts
+++ b/src/conversions/measures/volume.ts
@@ -23,7 +23,7 @@ export const volume: Measure = {
 		...expandMacro(Macros.si, { names: ['liter', 'liters', 'litre', 'litres'], symbols: ['l', 'L'], ratio: 1e-3 }),
 
 		// https://en.wikipedia.org/wiki/Cubic_mile
-		{ names: ['cubic mile', 'cubic miles'], symbols: ['cu mi', 'mi3', 'mi³'], ratio: 4.2e3 },
+		{ names: ['cubic mile', 'cubic miles'], symbols: ['cu mi', 'mi3', 'mi³'], ratio: 4_168_181_825.440_579_4 },
 		// https://en.wikipedia.org/wiki/Acre-foot
 		{ names: ['acre-foot', 'acre-feet'], symbols: ['ac⋅ft', 'ac ft'], ratio: 1233.481_837_547_52 },
 		// https://en.wikipedia.org/wiki/Cubic_yard

--- a/src/converters/conversions/factor-consistency.test.ts
+++ b/src/converters/conversions/factor-consistency.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from 'vitest';
+import { area } from '../../conversions/measures/area';
+import { length } from '../../conversions/measures/length';
+import { volume } from '../../conversions/measures/volume';
+import type { Measure } from '../../conversions/types';
+
+function ratioOf(measure: Measure, name: string): number {
+	const entry = measure.units.find((unit) => unit.names.includes(name));
+	if (entry === undefined) {
+		throw new Error(`No unit named ${name}`);
+	}
+
+	const { ratio } = entry;
+	return typeof ratio === 'function' ? ratio() : Number(ratio);
+}
+
+// A squared/cubed unit's factor must be the linear unit's factor raised to that power.
+// Guards the hand-written tables against exponent/transcription drift like the cubic mile
+// factor, which read 4.2e3 (a swimming pool) instead of 1609.344^3 ≈ 4.2e9.
+const families = [
+	{ linear: 'mile', square: 'square mile', cubic: 'cubic mile' },
+	{ linear: 'yard', square: 'square yard', cubic: 'cubic yard' },
+	{ linear: 'foot', square: 'square foot', cubic: 'cubic foot' },
+	{ linear: 'inch', square: 'square inch', cubic: 'cubic inch' },
+];
+
+describe('imperial length/area/volume factor consistency', () => {
+	test.each(families)('$linear: square = length^2, cubic = length^3', ({ linear, square, cubic }) => {
+		const lengthRatio = ratioOf(length, linear);
+		expect(ratioOf(area, square) / lengthRatio ** 2).toBeCloseTo(1, 12);
+		expect(ratioOf(volume, cubic) / lengthRatio ** 3).toBeCloseTo(1, 12);
+	});
+});

--- a/src/converters/conversions/volume.test.ts
+++ b/src/converters/conversions/volume.test.ts
@@ -20,6 +20,11 @@ describe('conversions', () => {
 		{ from: [1, 'yd3'], to: [0.764_554_857_984, 'm3'] },
 		{ from: [27, 'ft3'], to: [1, 'yd3'] },
 
+		// 1 mile = 1760 yd = 5280 ft, so a cubic mile is 1760^3 cubic yards = 5280^3 cubic feet
+		{ from: [1, 'cubic mile'], to: [4_168_181_825.440_579_4, 'm3'] },
+		{ from: [1, 'cubic mile'], to: [1760 ** 3, 'yd3'] },
+		{ from: [1, 'cubic mile'], to: [5280 ** 3, 'ft3'] },
+
 		{ from: [1, 'US legal cup'], to: [240 + 0.000_000_000_000_03, 'mL'] },
 	]);
 });


### PR DESCRIPTION
`cubic mile` is defined with `ratio: 4.2e3`, i.e. 4200 m³ — roughly a backyard swimming pool. A cubic mile is 1609.344³ = 4,168,181,825.44 m³, so every conversion to or from `cubic mile` is silently off by a factor of ~992,424 (−99.9999%).

It looks like an exponent slip: the mantissa 4.2 is right but the exponent should be `e9`, not `e3` (4.168e9 rounds to 4.2e9). The comment above the entry already links the Wikipedia article giving 4,168,181,825 m³.

```js
convert(1, 'cubic mile').to('m3'); // 4200  ->  4168181825.4405794
```

The corrected value agrees with the international mile cubed (1609.344 m is exact, NIST SP 811), with pint (`Q(1, 'mile**3').to('m**3')` = 4168181825.44058), and with this file's own `cubic yard`/`cubic foot`/`cubic inch` factors, which are all `linear³` — `cubic mile` was the only one that wasn't. I used the shortest literal that round-trips to the exact double, since biome's `noPrecisionLoss` rejects the full `4_168_181_825.440_579_584`.

Tests: direct assertions for `cubic mile` (1 cubic mile = 1760³ yd³ = 5280³ ft³), plus a small `factor-consistency` test asserting every imperial square/cubic unit equals its linear factor squared/cubed — a guard against this whole transcription-drift class. It's red on the old value, green on the new one.

While diffing the volume table against pint I noticed two other, more debatable discrepancies that I left alone, in case you want follow-ups: `imperial barrel` is `0.16` vs 36 imp gal = 0.163659 (~2.2%; the unit is loosely defined), and `decade`/`century`/`millennium` use the Gregorian mean year (365.2425 d) while `year` is 365 d, so `1 decade` ≠ `10 year` internally (~0.066%).
