### PR TITLE
fix(area): correct square deci prefix factor

### DIFF
--- a/src/conversions/macros/definitions/area-si.ts
+++ b/src/conversions/macros/definitions/area-si.ts
@@ -8,7 +8,7 @@ export const areaSi: Macro = [
 	{ prefix: 'square kilo', symbol: 'k', value: 1e6, kind: 'big' },
 	{ prefix: 'square hecto', symbol: 'h', value: 1e4, kind: 'big' },
 	{ prefix: 'square deca', symbol: 'da', value: 1e2, kind: 'big' },
-	{ prefix: 'square deci', symbol: 'd', value: 1e-1, kind: 'small' },
+	{ prefix: 'square deci', symbol: 'd', value: 1e-2, kind: 'small' },
 	{ prefix: 'square centi', symbol: 'c', value: 1e-4, kind: 'small' },
 	{ prefix: 'square milli', symbol: 'm', value: 1e-6, kind: 'small' },
 	{ prefix: 'square micro', symbol: ['μ', 'µ'], value: 1e-12, kind: 'small' },

--- a/src/converters/conversions/area.test.ts
+++ b/src/converters/conversions/area.test.ts
@@ -14,6 +14,8 @@ describe('conversions', () => {
 		{ from: [2, 'square meter'], to: [2e-6, 'square kilometer'] },
 		{ from: [2, 'square meter'], to: [20_000, 'square centimeter'] },
 		{ from: [2, 'square centimeter'], to: [200.000_000_000_000_03, 'square millimeter'] },
+		{ from: [1, 'square meter'], to: [100, 'square decimeter'] },
+		{ from: [1, 'dm2'], to: [100, 'cm2'] },
 
 		{ from: [1, 'square inch'], to: [6.451_599_999_999_999, 'square centimeters'] },
 		{ from: [1, 'square foot'], to: [0.092_903_04, 'square meters'] },

--- a/src/converters/conversions/factor-consistency.test.ts
+++ b/src/converters/conversions/factor-consistency.test.ts
@@ -34,10 +34,8 @@ describe('imperial length/area/volume factor consistency', () => {
 	});
 });
 
-// The SI prefix macros are three hand-written copies of the same prefix list, so the squared and
-// cubed tables must be the linear one raised to that power. Guards against a prefix being left
-// un-exponentiated, like `square deci`: #545 re-exponentiated the area macro but missed that one
-// row, which read 1e-1 instead of 1e-2 for another four years.
+// The SI prefix macros are three hand-written copies of the same prefix list, so the squared and cubed tables must be the linear one raised to that power
+// Guards against a prefix being left un-exponentiated
 function factorOf(macro: Macro, prefix: string): number {
 	const group = macro.find((entry) => entry.prefix === prefix);
 	if (group === undefined) {

--- a/src/converters/conversions/factor-consistency.test.ts
+++ b/src/converters/conversions/factor-consistency.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from 'vitest';
+import { areaSi, si, volumeSi } from '../../conversions/macros/definitions/index.ts';
+import type { Macro } from '../../conversions/macros/types.ts';
 import { area } from '../../conversions/measures/area.ts';
 import { length } from '../../conversions/measures/length.ts';
 import { volume } from '../../conversions/measures/volume.ts';
@@ -29,5 +31,26 @@ describe('imperial length/area/volume factor consistency', () => {
 		const lengthRatio = ratioOf(length, linear);
 		expect(ratioOf(area, square) / lengthRatio ** 2).toBeCloseTo(1, 12);
 		expect(ratioOf(volume, cubic) / lengthRatio ** 3).toBeCloseTo(1, 12);
+	});
+});
+
+// The SI prefix macros are three hand-written copies of the same prefix list, so the squared and
+// cubed tables must be the linear one raised to that power. Guards against a prefix being left
+// un-exponentiated, like `square deci`: #545 re-exponentiated the area macro but missed that one
+// row, which read 1e-1 instead of 1e-2 for another four years.
+function factorOf(macro: Macro, prefix: string): number {
+	const group = macro.find((entry) => entry.prefix === prefix);
+	if (group === undefined) {
+		throw new Error(`No prefix named ${prefix}`);
+	}
+
+	return Number(group.value);
+}
+
+describe('SI prefix macro factor consistency', () => {
+	test.each(si.map(({ prefix }) => ({ prefix })))('$prefix: square = linear^2, cubic = linear^3', ({ prefix }) => {
+		const linear = factorOf(si, prefix);
+		expect(factorOf(areaSi, `square ${prefix}`) / linear ** 2).toBeCloseTo(1, 12);
+		expect(factorOf(volumeSi, `cubic ${prefix}`) / linear ** 3).toBeCloseTo(1, 12);
 	});
 });


### PR DESCRIPTION
06e72c6 ("fix(area): fix conversion ratios", closes #545) re-exponentiated the area SI macro from linear factors to squared ones, but `square deci` was left at 1e-1 while every other row was updated. #545 listed square km, cm, mm and μm, and the conversion tests added alongside that fix covered mm, km and cm, so the one remaining row went unnoticed.

As a result dm²/square decimetre has been off by a factor of 10 ever since: 1 dm² resolves to 0.1 m² instead of 0.01 m². It also makes `to('best')` report the wrong quantity for values given in dm².

be4e7f0 added factor-consistency tests after the same class of mistake hit cubic miles, but scoped them to the imperial families. This extends that suite to the SI prefix macros, where both bugs actually originated: for each linear prefix, the area macro must be its square and the volume macro its cube. That check fails on the old value, as do two new dm² conversion cases.

Closes #835